### PR TITLE
swc-windows-installer.py: Set default logging level to INFO

### DIFF
--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -43,7 +43,7 @@ import zipfile
 
 LOG = logging.getLogger('swc-windows-installer')
 LOG.addHandler(logging.StreamHandler())
-LOG.setLevel(logging.ERROR)
+LOG.setLevel(logging.INFO)
 
 
 if sys.version_info >= (3, 0):  # Python 3
@@ -274,8 +274,10 @@ if __name__ == '__main__':
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
-        '-v', '--verbose', choices=['info', 'debug'],
-        help='Verbosity')
+        '-v', '--verbose',
+        choices=['critical', 'error', 'warning', 'info', 'debug'],
+        help='Verbosity (defaults to {!r})'.format(
+            logging.getLevelName(LOG.level).lower()))
 
     args = parser.parse_args()
 


### PR DESCRIPTION
And add the other levels as --verbose choices, even though we
currently only use LOG.info and LOG.debug.  Many *nix commands are
silent by default and have options for increasing the verbosity, but
Ethan points out that we should probably default to the setting that
makes the most sense for new users.

Addresses #8.
