### PR TITLE
README.md: Link to GitHub releases for the most-recent compiled version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ installer.
 [py2exe]: http://py2exe.org/
 [inno]: http://www.jrsoftware.org/isinfo.php
 [inno-download]: http://www.jrsoftware.org/isdl.php
-[compiled]: http://files.software-carpentry.org/SWCarpentryInstaller.exe
+[compiled]: https://github.com/swcarpentry/windows-installer/releases/latest


### PR DESCRIPTION
This way we don't need to remember to push to
files.software-carpentry.org.  The linked page has the message from
the latest release and a link to the exectuable, when it used to be
just the exectuable.  A quick search didn't turn up a way to link
directly to the latest binary.  I'm not particularly worried about the
additional click though, and folks working up installation
instructions for a given workshop should probably be linking to an
explicit version anyway.
