### PR TITLE
README.md: Mention that R should be installed before running our installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The script:
 Building
 ========
 
-Building the Windows installer requires a Windows machine with Python,
+Building the Windows installer requires a Windows machine with [Python][],
 [py2exe][] and [Inno Setup][inno]. `py2exe` can be installed using `pip` and
 Inno Setup can be installed using the self-installing package from
 [the download page][inno-download].
@@ -31,13 +31,17 @@ Using
 =====
 
 Just have your students download and double-click the compiled
-installer.
+installer.  If you're using [R][], you'll have to install R before
+running this installer (because this installer searches likely paths
+to find R's `bin` directory).  Otherwise, you can run it whenever you
+like (e.g. either before or after installing [Python][]).
 
 [msysGit]: http://msysgit.github.io/
 [nano]: http://www.nano-editor.org/
 [SQLite]: http://www.sqlite.org/
 [nosetests]: https://nose.readthedocs.org/en/latest/usage.html
 [R]: http://www.r-project.org/
+[Python]: https://www.python.org/
 [py2exe]: http://py2exe.org/
 [inno]: http://www.jrsoftware.org/isinfo.php
 [inno-download]: http://www.jrsoftware.org/isdl.php


### PR DESCRIPTION
This came up in response to the v0.1 release announcement on
discuss@lists.software-carpentry.org [1](http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/2014-August/001932.html).

I've also added a link to Python (and used it where we mention Python)
to match the existing link to R.

Reported-by: John Blischak jdblischak@uchicago.edu
