### PR TITLE
swc-windows-installer.py: Add install_msysgit_binary and install Make

### DIFF
--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -5,6 +5,7 @@
 Helps mimic a *nix environment on Windows with as little work as possible.
 
 The script:
+* Installs GNU Make and makes it accessible from msysGit
 * Installs nano and makes it accessible from msysGit
 * Installs SQLite and makes it accessible from msysGit
 * Creates a ~/nano.rc with links to syntax highlighting configs
@@ -143,6 +144,18 @@ def zip_install(url, sha1, install_directory):
         LOG.info('existing installation at {}'.format(install_directory))
 
 
+def install_msysgit_binary(name, sha1, install_directory,
+                           tag='Git-1.9.4-preview20140815'):
+    """Download and install a binary from msysGit's bin directory"""
+    bytes = download(
+        url='https://github.com/msysgit/msysgit/raw/{}/bin/{}'.format(
+            tag, name),
+        sha1=sha1)
+    LOG.info('installing {} into {}'.format(name, install_directory))
+    with open(os.path.join(install_directory, name), 'wb') as f:
+        f.write(bytes)
+
+
 def install_nano(install_directory):
     """Download and install the nano text editor"""
     zip_install(
@@ -265,6 +278,9 @@ def main():
     nanorc_dir = os.path.join(swc_dir, 'share', 'nanorc')
     sqlite_dir = os.path.join(swc_dir, 'lib', 'sqlite')
     create_nosetests_entry_point(python_scripts_directory=bin_dir)
+    install_msysgit_binary(
+        name='make.exe', sha1='ad11047985c33ff57074f8e09d347fe122e047a4',
+        install_directory=bin_dir)
     install_nano(install_directory=nano_dir)
     install_nanorc(install_directory=nanorc_dir)
     install_sqlite(install_directory=sqlite_dir)


### PR DESCRIPTION
The whole msysGit dev environment is [large](https://github.com/swcarpentry/bc/pull/533#issuecomment-45986839):

  On Fri, Jun 13, 2014 at 01:22:01AM -0700, Mike Jackson wrote:

> Disk space is cheap but 2GB is still a big ask - attendees laptops
> can be quite old and limited in terms of space.

And may be [more difficult](https://github.com/swcarpentry/windows-installer/issues/6#issuecomment-52349647) to install than the Git for Windows packaging

  On Fri, Aug 15, 2014 at 12:46:21PM -0700, Ethan White wrote:

> My concern with installing msysGit is that the installer process
> was substantially more complicated (at least the last time I
> looked 6-12 months ago). My concern is that folks will get hung up
> on all of the options and at best feel confused/overwhelmed and at
> worse not end up with a working install.

Since that simple option (replace Git for Windows with the full
msysGit) isn't available, with this commit we just grab the Make
executable from the msysGit repository.  To make grabbing additional
binaries easier, I've implemented this with the generic
install_msysgit_binary.  I've also pinned the download to the most
recent tag (Git-1.9.4-preview20140815), to keep the sha1 from changing
under our feet.  However, the make.exe binary was last touched on
[2012-01-26](https://github.com/msysgit/msysgit/commit/cb9836b8a5ea9aa8f2cb7a373e58eeb6c000d4a7) and the last hash-changing commit was on [2007-08-06](https://github.com/msysgit/msysgit/commit/2914373028897add73217340e515f5d69d7dd027),
so it's not exactly a high-churn target ;).

It would be nice if Windows came with a package manager (or even if
msysGit was [compatible](http://thread.gmane.org/gmane.comp.version-control.git/246514/focus=20055) with the upstream MSYS) so we didn't have
to jump through all these hoops.
