### PR TITLE
README: Document GNU Make installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Helps mimic a *nix environment on Windows with as little work as possible.
 
 The script:
 
-* Installs [nano][] and makes it accessible from [msysGit][]
+* Installs [GNU Make][make] and makes it accessible from [msysGit][]
+* Installs [nano][] and makes it accessible from msysGit
 * Installs [SQLite][] and makes it accessible from msysGit
 * Creates a `~/nano.rc` with links to syntax highlighting configs
 * Provides standard [nosetests][] behavior for msysGit
@@ -19,6 +20,7 @@ To use:
 4. Run `swc-windows-installer.py`.  You should be able to simply
    double click the file in Windows.
 
+[make]: https://www.gnu.org/software/make/
 [msysGit]: http://msysgit.github.io/
 [msysgit-install]: https://github.com/msysgit/msysgit/releases
 [nano]: http://www.nano-editor.org/


### PR DESCRIPTION
Reported by @apawlik [on `discuss@`][1].  This was left out of
28f9c4d9 (swc-windows-installer.py: Add install_msysgit_binary and
install Make, 2014-09-19, #21), although it was mentioned [in the v0.2
release notes][2].

[1]: http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/2015-November/003511.html
[2]: https://github.com/swcarpentry/windows-installer/releases/tag/v0.2