### PR TITLE
swc-windows-installer.py: Bump SQLite from 3.8.8.3 to 3.9.2

### DIFF
--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -188,8 +188,8 @@ def install_nanorc(install_directory):
 def install_sqlite(install_directory):
     """Download and install the SQLite shell"""
     zip_install(
-        url='https://sqlite.org/2015/sqlite-shell-win32-x86-3080803.zip',
-        sha1='a57f43b96827c549eb647a126779794e88022e46',
+        url='https://sqlite.org/2015/sqlite-shell-win32-x86-3090200.zip',
+        sha1='25d78bbba37d2a0d9b9f86ed897e454ccc94d7b2',
         install_directory=install_directory)
 
 


### PR DESCRIPTION
Released on 2015-11-02 [1].  For a summary of changes since 3.8.8.3
(released on 2015-02-25), see [1].  The old code was giving me:

  ValueError: downloaded
  'https://sqlite.org/2014/sqlite-shell-win32-x86-3080803.zip' has the
  wrong SHA-1 hash: 8a99a3ddd27097b072093319cd6e79bfbfa7480f !=
  a57f43b96827c549eb647a126779794e88022e46

Although the 2014 in the old URL may have been a typo.

[1]: http://sqlite.org/news.html