### PR TITLE
Only download if file doesn't exist in current directory

### DIFF
--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -67,9 +67,12 @@ else:
 
 
 def download(url, sha1):
-    """Download a file and verify its hash"""
+    """Download a file (if not present in directory) and verify its hash"""
     LOG.debug('download {}'.format(url))
-    r = _urlopen(url)
+    if os.path.isfile(os.path.basename(url)):
+        r = open(os.path.basename(url))
+    else:
+        r = _urlopen(url)
     byte_content = r.read()
     download_sha1 = hashlib.sha1(byte_content).hexdigest()
     if download_sha1 != sha1:


### PR DESCRIPTION
This changes the URL download code to first check if the file exists in the current directory and uses that if it does before going ahead and download it.

I think this is a good thing as it allows us to package the installer alongside the packages it downloads on a USB key and have people use it at workshops without a working network.

Note that I have only tested these changes by directly running the installer script on my Linux machine.  I don't expect a Windows machine will be any different, but I don't have easy access to test it.