### PR TITLE
swc-windows-installer.py: Allow R-3.2.4revised\bin

### DIFF
--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -230,7 +230,7 @@ def get_r_bin_directory():
             os.environ.get('ProgramFiles', r'c:\Program Files'),
             os.environ.get('ProgramFiles(x86)', r'c:\Program Files(x86)'),
             ]:
-        bin_glob = os.path.join(pf, 'R', 'R-[0-9]*.[0-9]*.[0-9]*', 'bin')
+        bin_glob = os.path.join(pf, 'R', 'R-[0-9]*.[0-9]*.[0-9]*[a-z]*', 'bin')
         for path in glob.glob(bin_glob):
             version_dir = os.path.basename(os.path.dirname(path))
             version_match = version_re.match(version_dir)


### PR DESCRIPTION
On Thu, Apr 14, 2016 at 12:41:01PM -0700, Ethan White [wrote][1]:
> At a workshop I just ran we ran into issues with R not being in the
> path on a number of Windows computers. In the past this has been
> caused because R likes to change the path where it installs itself
> and we've needed to change the function that searches for R. The new
> path that is causing issues is:
>
> `C:\Program Files\R\R-3.2.4revised\bin`

Fixes #44.

[1]: https://github.com/swcarpentry/windows-installer/issues/44