### PR TITLE
Add options for alternate install directory; disable updating rc files

### DIFF
--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -377,12 +377,10 @@ if __name__ == '__main__':
              '(default: ${HOME}/.swc)')
     parser.add_argument(
         '--no-update-profile', dest='update_profile', action='store_false',
-        help="install files only; do not install paths to the user's "
-             ".bash_profile")
+        help="do not install updates to the user's .bash_profile")
     parser.add_argument(
         '--no-update-nanorc', dest='update_nanorc', action='store_false',
-        help="install files only; do not install updates to the user's "
-             "nanorc file")
+        help="do not install updates to the user's nano.rc file")
     parser.add_argument(
         '-v', '--verbose',
         choices=['critical', 'error', 'warning', 'info', 'debug'],

--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -216,7 +216,7 @@ def install_sqlite(install_directory):
 def create_nosetests_entry_point(python_scripts_directory):
     """Creates a terminal-based nosetests entry point for msysGit"""
     contents = '\n'.join([
-            '#!/usr/bin/env/ python',
+            '#!/usr/bin/env python',
             'import sys',
             'import nose',
             "if __name__ == '__main__':",

--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -207,14 +207,27 @@ def install_nano(install_directory):
         install_directory=install_directory)
 
 
-def install_nanorc(install_directory):
-    """Download and install nano syntax highlighting"""
+def install_nano_share_files(install_directory):
+    """Download and install nano syntax highlighting configuration files"""
+
     tar_install(
         url='http://www.nano-editor.org/dist/v2.2/nano-2.2.6.tar.gz',
         sha1='f2a628394f8dda1b9f28c7e7b89ccb9a6dbd302a',
         sha512='e1ee5d63725055290a5117b73352a8557cc3105c737643e341a95ebbb0cecb06c46f86a2363de8455e9de3940e3f920c47af92e19ef9c53862de8a605da08d8d',
         install_directory=install_directory,
-        strip_components=1)
+        strip_components=1,
+        include=[os.path.join('doc', 'syntax')])
+
+
+def install_nanorc(install_directory):
+    """
+    Install a nano.rc file into the home directory which includes
+    installed syntax highlighting configurations.
+
+    In this case install_directory is the path to nano share files
+    installed by install_nano_share_files.
+    """
+
     home = os.path.expanduser('~')
     nanorc = os.path.join(home, 'nano.rc')
     if not os.path.isfile(nanorc):
@@ -332,15 +345,16 @@ def main(args):
     make_dir = os.path.join(swc_dir, 'opt', 'make')
     make_bin = os.path.join(make_dir, 'bin')
     nano_dir = os.path.join(swc_dir, 'opt', 'nano')
-    nanorc_dir = os.path.join(swc_dir, 'share', 'nanorc')
+    nano_share_dir = os.path.join(swc_dir, 'share', 'nano')
     sqlite_dir = os.path.join(swc_dir, 'opt', 'sqlite')
     create_nosetests_entry_point(python_scripts_directory=bin_dir)
     install_make(install_directory=make_dir)
     install_nano(install_directory=nano_dir)
+    install_nano_share_files(install_directory=nano_share_dir)
     install_sqlite(install_directory=sqlite_dir)
 
     if args.update_nanorc:
-        install_nanorc(install_directory=nanorc_dir)
+        install_nanorc(install_directory=nano_share_dir)
 
     if args.update_profile:
         paths = [make_bin, nano_dir, sqlite_dir, bin_dir]

--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -233,7 +233,7 @@ def install_nanorc(install_directory):
     if not os.path.isfile(nanorc):
         syntax_dir = os.path.join(install_directory, 'doc', 'syntax')
         LOG.info('include nanorc from {} in {}'.format(syntax_dir, nanorc))
-        with open3(nanorc, 'w', newline='\n') as f:
+        with open3(nanorc, 'a', newline='\n') as f:
             for filename in os.listdir(syntax_dir):
                 if filename.endswith('.nanorc'):
                     path = os.path.join(syntax_dir, filename)


### PR DESCRIPTION
This is a bit of preliminary work toward #56 .  

It doesn't change any of the existing (default) behavior of the installer, but will also allow me to use it in building an executable that includes all files.  So this way I can use the existing script to download and "install" all software into directory that will ultimately be included in the installer archive.