### PR TITLE
Bypass SSL certification for downloading.

### DIFF
--- a/swc-windows-installer.py
+++ b/swc-windows-installer.py
@@ -41,6 +41,7 @@ try:  # Python 3
     from urllib.request import urlopen as _urlopen
 except ImportError:  # Python 2
     from urllib2 import urlopen as _urlopen
+import ssl
 import zipfile
 
 
@@ -69,7 +70,7 @@ else:
 def download(url, sha1):
     """Download a file and verify its hash"""
     LOG.debug('download {}'.format(url))
-    r = _urlopen(url)
+    r = _urlopen(url, context=ssl._create_unverified_context())
     byte_content = r.read()
     download_sha1 = hashlib.sha1(byte_content).hexdigest()
     if download_sha1 != sha1:


### PR DESCRIPTION
This may not be the best way to solve this issue but we need it quickly or participants cannot use nano (we'd have to use vim or notepad instead).

Otherwise the http://www.nano-editor.org/dist/v2.2/NT/nano-2.2.6.zip
download fails with
"error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"